### PR TITLE
Change highlightKeys to accept a key and color dictionary

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -87,7 +87,7 @@ class ViewController: UIViewController, GLNPianoViewDelegate {
             highlightKeys[Note.number(of: noteString)!] = playingColor
         }
         
-        keyboard.highlightKeys(highlightKeys, play: play)
+        keyboard.highlightKeys(highlightKeys.map {($0.key, $0.value)}, play: play)
         let delay = 60.0/tempo
         let nextPosition = position + 1
         if nextPosition < score.count {

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -73,7 +73,21 @@ class ViewController: UIViewController, GLNPianoViewDelegate {
     }
     
     func autoHighlight(score: [[String]], position: Int, loop: Bool, tempo: Double, play: Bool) {
-        keyboard.highlightKeys(score[position], color: UIColor.init(red: 1.0, green: 0.0, blue: 0.0, alpha: 0.35), play: play)
+        let playingColor = UIColor.init(red: 1.0, green: 0.0, blue: 0.0, alpha: 0.35)
+        let highlightColor = UIColor.init(red: 1.0, green: 0.0, blue: 0.0, alpha: 0.15)
+        
+        // Collect all included notes in score
+        var highlightKeys: [Int: UIColor] = [:]
+        for step in score {
+            for noteString in step {
+                highlightKeys[Note.number(of: noteString)!] = highlightColor
+            }
+        }
+        for noteString in score[position] {
+            highlightKeys[Note.number(of: noteString)!] = playingColor
+        }
+        
+        keyboard.highlightKeys(highlightKeys, play: play)
         let delay = 60.0/tempo
         let nextPosition = position + 1
         if nextPosition < score.count {

--- a/Source/GLNPianoView.swift
+++ b/Source/GLNPianoView.swift
@@ -188,10 +188,11 @@ import UIKit
         return keyNum
     }
 
-    public func highlightKeys(_ noteNames: [String], color: UIColor, play: Bool) {
+    public func highlightKeys(_ keysAndColors: [Int:UIColor], play: Bool) {
+//    public func highlightKeys(_ noteNames: [String], color: UIColor, play: Bool) {
         reset()
-        for note in noteNames {
-            let noteNumber = Note.number(of: note)
+        for (key, color) in keysAndColors {
+            let noteNumber = key
             for key in keysArray {
                 if let key = key  {
                     if key.noteNumber == noteNumber {

--- a/Source/GLNPianoView.swift
+++ b/Source/GLNPianoView.swift
@@ -189,7 +189,6 @@ import UIKit
     }
 
     public func highlightKeys(_ keysAndColors: [(noteNumber: Int, color: UIColor)], play: Bool) {
-//    public func highlightKeys(_ noteNames: [String], color: UIColor, play: Bool) {
         reset()
         for (noteNumber, color) in keysAndColors {
             for key in keysArray {

--- a/Source/GLNPianoView.swift
+++ b/Source/GLNPianoView.swift
@@ -188,11 +188,10 @@ import UIKit
         return keyNum
     }
 
-    public func highlightKeys(_ keysAndColors: [Int:UIColor], play: Bool) {
+    public func highlightKeys(_ keysAndColors: [(noteNumber: Int, color: UIColor)], play: Bool) {
 //    public func highlightKeys(_ noteNames: [String], color: UIColor, play: Bool) {
         reset()
-        for (key, color) in keysAndColors {
-            let noteNumber = key
+        for (noteNumber, color) in keysAndColors {
             for key in keysArray {
                 if let key = key  {
                     if key.noteNumber == noteNumber {


### PR DESCRIPTION
### Breaking Change
- Change `highlightKeys` to accept a tuple-array of noteNumber and Color, so different keys could be highlight with different colors
- Change to using noteNumbers instead of Note names. (The user can always use `Note.number(of: String)` to do the conversion. I think that note number are un-opinionated.
- Updated example

This is a breaking change, so you might want to update major version.