### PR TITLE
Implement macOS compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "PianoKeyboard",
     platforms: [
-        .iOS("15.0")
+        .iOS("15.0"),
+        .macOS("15.0")
     ],
     products: [
         .library(

--- a/Source/RoundedCornersShape.swift
+++ b/Source/RoundedCornersShape.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 public struct RoundedCornersShape: Shape {
+    #if !os(macOS)
+
     let corners: UIRectCorner
     let radius: CGFloat
 
@@ -24,4 +26,39 @@ public struct RoundedCornersShape: Shape {
         )
         return Path(path.cgPath)
     }
+
+    #else
+
+    public struct WhatCorners: OptionSet, Sendable {
+        public let rawValue : Int8
+
+        public init(rawValue: Int8) {
+            self.rawValue = rawValue
+        }
+
+        public static let topLeft      = WhatCorners(rawValue: 1<<0)
+        public static let topRight     = WhatCorners(rawValue: 1<<1)
+        public static let bottomLeft   = WhatCorners(rawValue: 1<<2)
+        public static let bottomRight  = WhatCorners(rawValue: 1<<3)
+        public static let allCorners   : WhatCorners = [topLeft, topRight, bottomLeft, bottomRight]
+    }
+    let corners: WhatCorners
+    let radius: CGFloat
+
+    public init(corners: WhatCorners, radius: CGFloat) {
+        self.corners = corners
+        self.radius = radius
+    }
+
+    public func path(in rect: CGRect) -> Path {
+        return UnevenRoundedRectangle(
+            topLeadingRadius: (corners.contains(.topLeft) ? radius : 0),
+            bottomLeadingRadius: (corners.contains(.bottomLeft) ? radius : 0),
+            bottomTrailingRadius: (corners.contains(.bottomRight) ? radius : 0),
+            topTrailingRadius: (corners.contains(.topRight) ? radius : 0),
+            style: .continuous
+        ).path(in: rect)
+    }
+
+    #endif
 }

--- a/Source/TouchesView.swift
+++ b/Source/TouchesView.swift
@@ -7,23 +7,45 @@
 
 import SwiftUI
 
-struct TouchesView: UIViewRepresentable {
+#if !os(macOS)
+public typealias PlatformView = UIView
+public typealias PlatformViewRepresentable = UIViewRepresentable
+#else
+public typealias PlatformView = NSView
+public typealias PlatformViewRepresentable = NSViewRepresentable
+#endif
+
+struct TouchesView: PlatformViewRepresentable {
     var viewModel: PianoKeyboardViewModel
 
-    func makeUIView(context: Context) -> TouchesUIView {
-        let touchesUIView = TouchesUIView()
+    #if !os(macOS)
+
+    func makeUIView(context: Context) -> PlatformView {
+        let touchesUIView = TouchesPlatformView()
         touchesUIView.isMultipleTouchEnabled = true
         touchesUIView.delegate = context.coordinator
         return touchesUIView
     }
 
-    func updateUIView(_ uiView: TouchesUIView, context: Context) {}
+    func updateUIView(_ uiView: PlatformView, context: Context) {}
+
+    #else
+
+    func makeNSView(context: Context) -> PlatformView {
+        let touchesNSView = TouchesPlatformView()
+        touchesNSView.delegate = context.coordinator
+        return touchesNSView
+    }
+
+    func updateNSView(_ uiView: PlatformView, context: Context) {}
+
+    #endif
 
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
 
-    class Coordinator: NSObject, TouchesUIViewDelegate {
+    class Coordinator: NSObject, TouchesPlatformViewDelegate {
         var parent: TouchesView
         var touches: [CGPoint] = [] {
             didSet {
@@ -37,15 +59,18 @@ struct TouchesView: UIViewRepresentable {
     }
 }
 
-protocol TouchesUIViewDelegate: AnyObject {
+protocol TouchesPlatformViewDelegate: AnyObject {
     var touches: [CGPoint] { get set }
 }
 
-class TouchesUIView: UIView {
+class TouchesPlatformView: PlatformView {
     static var minNumberOfKeys: Int = 12
     static var maxNumberOfKeys: Int = 61
 
-    weak var delegate: TouchesUIViewDelegate?
+    weak var delegate: TouchesPlatformViewDelegate?
+
+    #if !os(macOS)
+
     var currentTouches = NSMutableSet(capacity: Int(maxNumberOfKeys))
 
     func updateKeys() {
@@ -82,4 +107,19 @@ class TouchesUIView: UIView {
         }
         updateKeys()
     }
+
+    #else
+
+    public override func mouseDown(with event: NSEvent) {
+        let windowMaxY = event.window?.frame.height ?? 0
+        let click      = event.locationInWindow
+
+        delegate?.touches = [CGPoint(x: click.x, y: windowMaxY-click.y)]
+    }
+
+    public override func mouseUp(with event: NSEvent) {
+        delegate?.touches = []
+    }
+
+    #endif
 }


### PR DESCRIPTION
This PR makes the package work on native (non-Catalyst) macOS. There are three changes:

1. Add `macOS` to the `platforms` of the Package description.
2. Implement an alternative for RoundedCornersShape.
    * This is more general than it really needs to be. The package always calls this with the two bottom corners to be rounded.
    * I picked `.continuous` as the style. Not sure whether `.circular` would look better.
    * The `macOS` implementation would in fact work cross platform, so this could be simplified.
3. Implement a macOS equivalent to `TouchesView`. This needs some ugly coordinate adjustment — not quite sure what the idiomatic solution would be.

Thanks for creating this very useful package! 